### PR TITLE
Change dashlist to widthlist in DrawData::getWidth

### DIFF
--- a/src/main/java/wprover/DrawData.java
+++ b/src/main/java/wprover/DrawData.java
@@ -96,9 +96,9 @@ public class DrawData {
     public static double getWidth(int index) {
         double d;
         try {
-            d = (double) dd.dashlist.get(index);
+            d = (double) dd.widthlist.get(index);
         } catch (ClassCastException cce) {
-            d = (int) dd.dashlist.get(index);
+            d = (int) dd.widthlist.get(index);
         }
         return d;
     }


### PR DESCRIPTION
This commit fixes an issue where if you right click on a line, choose properties and try to change the width, then an index out of range exception is thrown.