### PR TITLE
Corrected a typo on Rule 4 for the GDD in keys.pot

### DIFF
--- a/src/main/po/de.po
+++ b/src/main/po/de.po
@@ -2854,8 +2854,8 @@ msgstr ""
 "Ist AB ∥ CD und E der Schnittpunkt von AC und BD, dann gilt EA / EC = EB / "
 "ED."
 
-msgid "If AB ∥ EF and CD ⊥ EF, then CD ⊥ EF."
-msgstr "Wenn AB ∥ CD und CD ⊥ EF, dann gilt AB ⊥ EF."
+msgid "If AB ∥ EF and CD ⊥ AB, then CD ⊥ EF."
+msgstr "Wenn AB ∥ EF und CD ⊥ AB, dann gilt CD ⊥ EF."
 
 msgid "If AB ⊥ CD, then ∠[AB,CD] = [1] (or 90 degrees)."
 msgstr "Wenn AB ⊥ CD, dann gilt ∠[AB,CD] = [1] (oder 90 Grad)."

--- a/src/main/po/fa.po
+++ b/src/main/po/fa.po
@@ -2898,7 +2898,7 @@ msgid ""
 msgstr ""
 
 # GDD 4 /1
-msgid "If AB ∥ EF and CD ⊥ EF, then CD ⊥ EF."
+msgid "If AB ∥ EF and CD ⊥ AB, then CD ⊥ EF."
 msgstr ""
 
 # GDD 5/1

--- a/src/main/po/fr.po
+++ b/src/main/po/fr.po
@@ -2869,8 +2869,8 @@ msgstr ""
 "Si AB ∥ CD et E est l'intersection de AC et BD, alors EA / EC = EB / ED."
 
 # GDD 4 /1
-msgid "If AB ∥ EF and CD ⊥ EF, then CD ⊥ EF."
-msgstr "Si AB ∥ EF et CD ⊥ EF, alors CD ⊥ EF."
+msgid "If AB ∥ EF and CD ⊥ AB, then CD ⊥ EF."
+msgstr "Si AB ∥ EF et CD ⊥ AB, alors CD ⊥ EF."
 
 # GDD 5/1
 msgid "If AB ⊥ CD, then ∠[AB,CD] = [1] (or 90 degrees)."

--- a/src/main/po/he.po
+++ b/src/main/po/he.po
@@ -2846,7 +2846,7 @@ msgstr ""
 
 # GDD 4 /1
 #, fuzzy
-msgid "If AB ∥ EF and CD ⊥ EF, then CD ⊥ EF."
+msgid "If AB ∥ EF and CD ⊥ AB, then CD ⊥ EF."
 msgstr "אם AB מקביל לEF ו CD מאונך ל EF, אזי CD מאונך ל EF."
 
 # GDD 5/1

--- a/src/main/po/hu.po
+++ b/src/main/po/hu.po
@@ -2843,8 +2843,8 @@ msgid ""
 msgstr "Ha AB ∥ CD és E az AC és BD metszete, akkor EA / EC = EB / ED."
 
 # GDD 4 /1
-msgid "If AB ∥ EF and CD ⊥ EF, then CD ⊥ EF."
-msgstr "Ha AB ∥ EF és CD ⊥ EF, akkor CD ⊥ EF."
+msgid "If AB ∥ EF and CD ⊥ AB, then CD ⊥ EF."
+msgstr "Ha AB ∥ EF és CD ⊥ AB, akkor CD ⊥ EF."
 
 # GDD 5/1
 msgid "If AB ⊥ CD, then ∠[AB,CD] = [1] (or 90 degrees)."

--- a/src/main/po/it.po
+++ b/src/main/po/it.po
@@ -2940,7 +2940,7 @@ msgid ""
 msgstr ""
 
 # GDD 4 /1
-msgid "If AB ∥ EF and CD ⊥ EF, then CD ⊥ EF."
+msgid "If AB ∥ EF and CD ⊥ AB, then CD ⊥ EF."
 msgstr ""
 
 # GDD 5/1

--- a/src/main/po/keys.pot
+++ b/src/main/po/keys.pot
@@ -2804,7 +2804,7 @@ msgid "If AB ∥ CD and E is the intersection of AC and BD, then EA / EC = EB / 
 msgstr ""
 
 # GDD 4 /1
-msgid "If AB ∥ EF and CD ⊥ EF, then CD ⊥ EF."
+msgid "If AB ∥ EF and CD ⊥ AB, then CD ⊥ EF."
 msgstr ""
 
 # GDD 5/1

--- a/src/main/po/pl.po
+++ b/src/main/po/pl.po
@@ -2855,8 +2855,8 @@ msgstr ""
 
 # GDD 4 /1
 #, fuzzy
-msgid "If AB ∥ EF and CD ⊥ EF, then CD ⊥ EF."
-msgstr "Jeśli AB ∥ EF i CD ⊥ EF, to CD ⊥ EF."
+msgid "If AB ∥ EF and CD ⊥ AB, then CD ⊥ EF."
+msgstr "Jeśli AB ∥ EF i CD ⊥ AB, to CD ⊥ EF."
 
 # GDD 5/1
 #, fuzzy

--- a/src/main/po/pt.po
+++ b/src/main/po/pt.po
@@ -2880,8 +2880,8 @@ msgid "If AB ∥ CD and E is the intersection of AC and BD, then EA / EC = EB / 
 msgstr "Se AB ∥ CD e E é a interseção de AC com BD, então EA / EC = EB / ED."
 
 # GDD 4 /1
-msgid "If AB ∥ EF and CD ⊥ EF, then CD ⊥ EF."
-msgstr "Se AB ∥ EF e CD ⊥ EF, então CD ⊥ EF."
+msgid "If AB ∥ EF and CD ⊥ AB, then CD ⊥ EF."
+msgstr "Se AB ∥ EF e CD ⊥ AB, então CD ⊥ EF."
 
 # GDD 5/1
 msgid "If AB ⊥ CD, then ∠[AB,CD] = [1] (or 90 degrees)."

--- a/src/main/po/rs.po
+++ b/src/main/po/rs.po
@@ -2877,8 +2877,8 @@ msgid ""
 msgstr "Ako je AB ∥ CD i E je presek AC i BD, onda je i EA / EC = EB / ED."
 
 # GDD 4 /1
-msgid "If AB ∥ EF and CD ⊥ EF, then CD ⊥ EF."
-msgstr "Ako je AB ∥ EF i CD ⊥ EF, onda je i CD ⊥ EF."
+msgid "If AB ∥ EF and CD ⊥ AB, then CD ⊥ EF."
+msgstr "Ako je AB ∥ EF i CD ⊥ AB, onda je i CD ⊥ EF."
 
 # GDD 5/1
 msgid "If AB ⊥ CD, then ∠[AB,CD] = [1] (or 90 degrees)."

--- a/src/main/po/zh_CN.po
+++ b/src/main/po/zh_CN.po
@@ -2935,7 +2935,7 @@ msgid ""
 msgstr ""
 
 # GDD 4 /1
-msgid "If AB ∥ EF and CD ⊥ EF, then CD ⊥ EF."
+msgid "If AB ∥ EF and CD ⊥ AB, then CD ⊥ EF."
 msgstr ""
 
 # GDD 5/1


### PR DESCRIPTION
Rule 4 stated that "If AB || EF and CD ⊥ EF, then CD ⊥ EF". It should be "If AB || EF and CD ⊥ AB, then CD ⊥ EF". I've corrected this on the keys.pot file and all of the current .po files. I've also updated the translation in all languages in which there wasw a translation for the rule text except for hebrew. The hebrew language structure is too different to what I know for me to be sure that I would change the correct text.